### PR TITLE
Adicao de data ao arquivo e especificacao do diretorio

### DIFF
--- a/README
+++ b/README
@@ -17,4 +17,5 @@ password = 'GEPON'
 FTPSERVER = '200.200.200.200'
 ftpuser = 'user'
 ftppassword = '123456'
+ftpdirectory = ''
 =======================================================================

--- a/bk-olt-fiberhome.py
+++ b/bk-olt-fiberhome.py
@@ -54,7 +54,7 @@ mydate = arrow.now().format('YYYY-MM-DD')
 
 
 #sending commando to copy configuration file to remote FTP server
-child.sendline ('upload ftp config '+FTPSERVER+' '+ftpuser+' '+ftppassword+' '+ftpdirectory+'/bk-olt-'+HOST+'-.cfg')
+child.sendline ('upload ftp config '+FTPSERVER+' '+ftpuser+' '+ftppassword+' '+ftpdirectory+'/bk-olt-'+HOST+'-'+mydate+'.cfg')
 time.sleep(10)
 
 #exiting connection

--- a/bk-olt-fiberhome.py
+++ b/bk-olt-fiberhome.py
@@ -12,6 +12,7 @@
 import sys,pexpect
 import getpass
 import time
+import arrow
 
 HOST = sys.argv[1]
 
@@ -22,6 +23,7 @@ password = 'GEPON'
 FTPSERVER = '200.200.200.200'
 ftpuser = 'user'
 ftppassword = '123456'
+ftpdirectory = '/backups'
 #=======================================================================
 
 
@@ -46,8 +48,13 @@ child.sendline (password) #sending enable password
 time.sleep(3)
 child.expect('#')
 
+
+#defining the actual date to be add to the filename
+mydate = arrow.now().format('YYYY-MM-DD')
+
+
 #sending commando to copy configuration file to remote FTP server
-child.sendline ('upload ftp config '+FTPSERVER+' '+ftpuser+' '+ftppassword+' bk-olt-'+HOST+'-.cfg')
+child.sendline ('upload ftp config '+FTPSERVER+' '+ftpuser+' '+ftppassword+' '+ftpdirectory+'/bk-olt-'+HOST+'-.cfg')
 time.sleep(10)
 
 #exiting connection


### PR DESCRIPTION
Para que os arquivos  não se sobrescrevam é necessário adicionar a data ao nome do arquivo, também adicionei a especificação do diretório de ftp , necessário quando utilizamos um mesmo ftp para diferentes backups (organização)